### PR TITLE
🧹 Remove unused import 'os' in upscaler.py

### DIFF
--- a/upscaler.py
+++ b/upscaler.py
@@ -5,7 +5,6 @@ A Python wrapper for the Upscayl CLI tool that provides batch processing
 and easy-to-use options for upscaling images.
 """
 
-import os
 import sys
 import subprocess
 import argparse


### PR DESCRIPTION
This PR removes an unused `import os` statement from `upscaler.py`.

🎯 **What:** Removed `import os` from `upscaler.py`.
💡 **Why:** The `os` module was not referenced anywhere in the file, making it dead code. Removing it improves maintainability and follows clean code practices.
✅ **Verification:**
- Ran `ruff check upscaler.py` to confirm the import was indeed unused and that it is now removed.
- Ran `python3 upscaler.py --help` to ensure the script still loads and runs correctly.
✨ **Result:** Cleaner code with one less unnecessary dependency in the main script.

---
*PR created automatically by Jules for task [12204288287591704387](https://jules.google.com/task/12204288287591704387) started by @Ven0m0*